### PR TITLE
[DOCS] Consoldate documentation after code migration to `shrugify`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,13 +2,13 @@ changelog:
   exclude:
     labels:
       - duplicate
-      - 'good first issue'
-      - 'help wanted'
-      - invalid
       - needs-tests
       - question
       - wontfix
   categories:
+    - title: 🚨 Security
+      labels:
+        - security
     - title: ⚡ Breaking
       labels:
         - breaking
@@ -21,12 +21,10 @@ changelog:
     - title: 👷 Changed
       labels:
         - maintenance
+        - "*"
     - title: 📖 Documentation
       labels:
         - documentation
     - title: ⚙️ Dependencies
       labels:
         - dependencies
-    - title: Other changes
-      labels:
-        - "*"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![PHP Version Require](http://poser.pugx.org/shrug/zealous-stan/require/php)](https://packagist.org/packages/shrug/zealous-stan)
-[![CGL](https://github.com/mteu/zealous-stan/actions/workflows/cgl.yaml/badge.svg)](https://github.com/mteu/zealous-stan/actions/workflows/cgl.yaml)
+[![CGL](https://github.com/shrugify/zealous-stan/actions/workflows/cgl.yaml/badge.svg)](https://github.com/shrugify/zealous-stan/actions/workflows/cgl.yaml)
 [![Latest Stable Version](http://poser.pugx.org/shrug/zealous-stan/v)](https://packagist.org/packages/shrug/zealous-stan)
 [![License](http://poser.pugx.org/shrug/zealous-stan/license)](https://packagist.org/packages/shrug/zealous-stan)
 


### PR DESCRIPTION
This PR aligns the code with the migration to the [github.com/shrugify](https://github.com/shrugify) organisation. The migration will harmonize the source code for the Packagist [`shrug`](https://packagist.org/packages/shrug/zealous-stan) vendor.